### PR TITLE
Make sure there is a resource representation

### DIFF
--- a/models/m_rdf.erl
+++ b/models/m_rdf.erl
@@ -96,7 +96,10 @@ rsc(Url, Context) ->
 %% @doc Export resource to a set of triples
 -spec to_triples(integer(), #context{}) -> #rdf_resource{}.
 to_triples(Id, Context) ->
-    Props = m_rsc:get_visible(Id, Context),
+    Props = case m_rsc:get_visible(Id, Context) of
+		undefined -> [];
+		VisibleProps -> VisibleProps
+	end,
 
     Triples = lists:flatten(
         %% Resource properties


### PR DESCRIPTION
There are some situations where a resource has no visible properties but still needs a RDF representation.